### PR TITLE
Add URL extraction and validation functions; implement endpoint extraction from Java files

### DIFF
--- a/src/Scripts/Url.py
+++ b/src/Scripts/Url.py
@@ -1,8 +1,24 @@
 import requests
 from bs4 import BeautifulSoup
+from urllib.parse import urlparse
 
 def extract_urls(url):
-    response = requests.get(url)
+    """
+    Extrai todas as URLs de uma página web.
+
+    Args:
+        url (str): A URL da página web.
+
+    Returns:
+        list: Uma lista de URLs extraídas.
+    """
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Verifica se a requisição foi bem-sucedida
+    except requests.RequestException as e:
+        print(f"Erro ao acessar a URL: {e}")
+        return []
+
     soup = BeautifulSoup(response.content, 'html.parser')
     urls = []
 
@@ -11,9 +27,25 @@ def extract_urls(url):
 
     return urls
 
-# Exemplo de uso
-url_to_test = 'http://'
-extracted_urls = extract_urls(url_to_test)
+def is_valid_url(url):
+    """
+    Verifica se uma URL é válida.
 
-for url in extracted_urls:
-    print(url)
+    Args:
+        url (str): A URL a ser verificada.
+
+    Returns:
+        bool: True se a URL for válida, False caso contrário.
+    """
+    parsed = urlparse(url)
+    return bool(parsed.netloc) and bool(parsed.scheme)
+
+if __name__ == "__main__":
+    url_to_test = 'http://example.com'
+    
+    if is_valid_url(url_to_test):
+        extracted_urls = extract_urls(url_to_test)
+        for url in extracted_urls:
+            print(url)
+    else:
+        print("URL inválida")

--- a/src/Scripts/UrlPart2.py
+++ b/src/Scripts/UrlPart2.py
@@ -1,0 +1,61 @@
+import os
+import javalang
+
+def extract_endpoints_from_file(file_path):
+    """
+    Extrai endpoints de um arquivo Java.
+
+    Args:
+        file_path (str): O caminho do arquivo Java.
+
+    Returns:
+        list: Uma lista de endpoints extraídos.
+    """
+    with open(file_path, 'r', encoding='utf-8') as file:
+        java_code = file.read()
+
+    tree = javalang.parse.parse(java_code)
+    endpoints = []
+
+    for path, node in tree:
+        if isinstance(node, javalang.tree.MethodDeclaration):
+            annotations = [annotation.name for annotation in node.annotations]
+            if any(annotation in annotations for annotation in ['RequestMapping', 'GetMapping', 'PostMapping']):
+                endpoint = {
+                    'name': node.name,
+                    'parameters': [param.name for param in node.parameters]
+                }
+                endpoints.append(endpoint)
+
+    return endpoints
+
+def extract_endpoints_from_directory(directory_path):
+    """
+    Extrai endpoints de todos os arquivos Java em um diretório.
+
+    Args:
+        directory_path (str): O caminho do diretório.
+
+    Returns:
+        dict: Um dicionário com os caminhos dos arquivos como chaves e listas de endpoints como valores.
+    """
+    endpoints_by_file = {}
+
+    for root, _, files in os.walk(directory_path):
+        for file in files:
+            if file.endswith('.java'):
+                file_path = os.path.join(root, file)
+                endpoints = extract_endpoints_from_file(file_path)
+                if endpoints:
+                    endpoints_by_file[file_path] = endpoints
+
+    return endpoints_by_file
+
+if __name__ == "__main__":
+    project_directory = '/path/to/your/java/project'
+    
+    endpoints = extract_endpoints_from_directory(project_directory)
+    for file_path, endpoints_list in endpoints.items():
+        print(f"File: {file_path}")
+        for endpoint in endpoints_list:
+            print(f"  Endpoint: {endpoint['name']}, Parameters: {endpoint['parameters']}")


### PR DESCRIPTION
Explicação do Código
Função extract_endpoints_from_file:

Lê o conteúdo de um arquivo Java.
Faz o parsing do código-fonte Java.
Itera sobre os nós da árvore de sintaxe abstrata (AST).
Verifica se o nó é uma declaração de método e se possui anotações de mapeamento de endpoints (RequestMapping, GetMapping, PostMapping).
Extrai o nome do método e os parâmetros.
Adiciona as informações extraídas a uma lista de endpoints.
Função extract_endpoints_from_directory:

Percorre todos os arquivos no diretório especificado.
Para cada arquivo Java, chama a função extract_endpoints_from_file.
Armazena os endpoints extraídos em um dicionário, onde as chaves são os caminhos dos arquivos e os valores são listas de endpoints.
Exemplo de Uso:

Define o caminho do diretório do projeto Java.
Chama a função extract_endpoints_from_directory com o caminho do diretório.
Imprime os endpoints extraídos para cada arquivo Java.
Observação
Substitua '/path/to/your/java/project' pelo caminho real do diretório do seu projeto Java. Essa abordagem permite analisar todos os arquivos Java em um diretório e extrair informações sobre os endpoints e seus parâmetros, facilitando consultas e testes de maneira semelhante ao Swagger.